### PR TITLE
Added support for a list of trusted groups.

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -97,13 +97,15 @@ function createGroupFilter(_options){
     throw new Error('inGroup is the only supported filter at this time.  PR welcome!');
   }
 
+  opts.inGroup = typeof opts.inGroup === 'string' ? [opts.inGroup] : opts.inGroup;
+
   return function groupFilter(req,res,next){
     req.account.getGroups(function(err,collection){
       if(err){
         next(err);
       }else{
         collection.detect(function(group,cb){
-          cb(opts.inGroup === group.name);
+          cb(opts.inGroup.indexOf(group.name) >= 0);
         },function(result){
           if(result){
             next();

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "bluebird": "^2.3.10",
     "assert-plus": "^0.1.5",
+    "bluebird": "^2.3.10",
+    "minimist": "0.0.8",
     "restify": "^2.8.3",
     "stormpath": "^0.7.0",
-    "uuid": "^2.0.1",
     "underscore": "^1.7.0",
-    "prettyjson": "^1.0.0",
-    "prompt": "^0.2.14"
+    "uuid": "^2.0.1",
+    "wrappy": "^1.0.1"
   }
 }


### PR DESCRIPTION
I had a need to have a list of trusted groups. This minor update adds support for providing the createGroupFilter `inGroup` attribute with a string _or an array_ of trusted groups.
